### PR TITLE
Add maximum-takeoff-mass-lbs and max-gear-extension-speed limits

### DIFF
--- a/aircraft/f-14b/f-14a-set.xml
+++ b/aircraft/f-14b/f-14a-set.xml
@@ -991,6 +991,15 @@
 		</refuel>
 	</systems>
 
+    <limits>
+        <mass-and-balance>
+            <!-- Reference: https://en.wikipedia.org/wiki/Grumman_F-14_Tomcat#Specifications_.28F-14D.29 -->
+            <maximum-takeoff-mass-lbs>74350</maximum-takeoff-mass-lbs>
+        </mass-and-balance>
+
+        <max-gear-extension-speed>270</max-gear-extension-speed>
+    </limits>
+
 	<consumables>
 		<fuel>
 			<tank n="0">
@@ -1451,6 +1460,9 @@ else
 		<aar>
 			<file>Aircraft/Generic/aar.nas</file>
 		</aar>
+        <limits>
+			<file>Aircraft/Generic/limits.nas</file>
+        </limits>
 		<radardist>
 			<file>Aircraft/Instruments-3d/radardist/radardist.nas</file>
 		</radardist>


### PR DESCRIPTION
Add some limits. If you extend the gear above 270 KIAS (which is the limit as you described on the mailing list) FlightGear will display a message near the top of the screen.

Possible additional limits include vne, max-positive-g, and max-negative-g.
