### PR TITLE
Add vapour color dialog to adjust smoke color

### DIFF
--- a/aircraft/f-14b/Models/Fx/smoke-trail-left.xml
+++ b/aircraft/f-14b/Models/Fx/smoke-trail-left.xml
@@ -53,9 +53,9 @@ based on standard my wingtip contrail:    rjh@zaretto.com
    <particle>
      <start>
        <color>
-         <red><expression><product><value>1.0</value><property>/rendering/scene/diffuse/red</property></product></expression></red>
-         <green><expression><product><value>1.0</value><property>/rendering/scene/diffuse/red</property></product></expression></green>
-         <blue><expression><product><value>1.0</value><property>/rendering/scene/diffuse/red</property></product></expression></blue>
+         <red><expression><product><property>sim/multiplay/generic/float[12]</property><property>/rendering/scene/diffuse/red</property></product></expression></red>
+         <green><expression><product><property>sim/multiplay/generic/float[13]</property><property>/rendering/scene/diffuse/red</property></product></expression></green>
+         <blue><expression><product><property>sim/multiplay/generic/float[14]</property><property>/rendering/scene/diffuse/red</property></product></expression></blue>
          <alpha><value> 0.6 </value></alpha>
        </color>
        <size>
@@ -65,9 +65,9 @@ based on standard my wingtip contrail:    rjh@zaretto.com
  
      <end>
        <color>
-         <red><expression><product><value>1.0</value><property>/rendering/scene/diffuse/red</property></product></expression></red>
-         <green><expression><product><value>1.0</value><property>/rendering/scene/diffuse/red</property></product></expression></green>
-         <blue><expression><product><value>1.0</value><property>/rendering/scene/diffuse/red</property></product></expression></blue>
+         <red><expression><product><property>sim/multiplay/generic/float[12]</property><property>/rendering/scene/diffuse/red</property></product></expression></red>
+         <green><expression><product><property>sim/multiplay/generic/float[13]</property><property>/rendering/scene/diffuse/red</property></product></expression></green>
+         <blue><expression><product><property>sim/multiplay/generic/float[14]</property><property>/rendering/scene/diffuse/red</property></product></expression></blue>
          <alpha><value> 0.00000001</value></alpha>
        </color>
        <size>

--- a/aircraft/f-14b/Models/Fx/smoke-trail-right.xml
+++ b/aircraft/f-14b/Models/Fx/smoke-trail-right.xml
@@ -1,0 +1,94 @@
+<!--
+based on standard my wingtip contrail:    rjh@zaretto.com
+ -->
+<PropertyList> 
+ <particlesystem>
+   <name>Smoke Generator</name>
+   <texture>vapour.png</texture>
+ 
+   <emissive type="bool">false</emissive>
+   <lighting type="bool">false</lighting>
+ 
+   <condition>
+      <greater-than>
+        <property>sim/multiplay/generic/float[1]</property>
+        <value>0.0</value>
+      </greater-than>
+   </condition>
+ 
+   <attach>world</attach>
+ 
+   <placer>
+     <type>point</type> 
+   </placer>
+ 
+   <shooter>
+     <theta-min-deg>89</theta-min-deg>
+      <theta-max-deg>91</theta-max-deg>
+      <phi-min-deg>6</phi-min-deg>
+      <phi-max-deg>-6</phi-max-deg>
+  <speed-mps>
+        <value>27</value>
+        <spread>12</spread>
+      </speed-mps>
+<rotation-speed>
+        <x-min-deg-sec>0</x-min-deg-sec>
+        <y-min-deg-sec>0</y-min-deg-sec>
+        <z-min-deg-sec>-180</z-min-deg-sec>
+        <x-max-deg-sec>0</x-max-deg-sec>
+        <y-max-deg-sec>0</y-max-deg-sec>
+        <z-max-deg-sec>180</z-max-deg-sec>
+      </rotation-speed>
+   </shooter>
+ 
+   <counter>
+     <particles-per-sec>
+       <value>190</value>
+       <spread>91</spread>
+     </particles-per-sec>
+   </counter>
+ 
+   <align>billboard</align>
+ 
+   <particle>
+     <start>
+       <color>
+         <red><expression><product><property>sim/multiplay/generic/float[15]</property><property>/rendering/scene/diffuse/red</property></product></expression></red>
+         <green><expression><product><property>sim/multiplay/generic/float[16]</property><property>/rendering/scene/diffuse/red</property></product></expression></green>
+         <blue><expression><product><property>sim/multiplay/generic/float[17]</property><property>/rendering/scene/diffuse/red</property></product></expression></blue>
+         <alpha><value> 0.6 </value></alpha>
+       </color>
+       <size>
+         <value>2.5</value>
+       </size>
+     </start>
+ 
+     <end>
+       <color>
+         <red><expression><product><property>sim/multiplay/generic/float[15]</property><property>/rendering/scene/diffuse/red</property></product></expression></red>
+         <green><expression><product><property>sim/multiplay/generic/float[16]</property><property>/rendering/scene/diffuse/red</property></product></expression></green>
+         <blue><expression><product><property>sim/multiplay/generic/float[17]</property><property>/rendering/scene/diffuse/red</property></product></expression></blue>
+         <alpha><value> 0.00000001</value></alpha>
+       </color>
+       <size>
+         <value>2.75</value>
+       </size>
+     </end>
+ 
+     <life-sec>
+       <value>20</value>
+     </life-sec>
+ 
+      <mass-kg>71.9</mass-kg>
+      <radius-m>1</radius-m>
+   </particle>
+ 
+   <program>
+     <fluid>               air  </fluid>
+     <gravity type="bool"> false </gravity>
+     <wind typ="bool">     true </wind>
+   </program>
+ 
+ </particlesystem>
+ 
+ </PropertyList>

--- a/aircraft/f-14b/Models/f-14b.xml
+++ b/aircraft/f-14b/Models/f-14b.xml
@@ -997,7 +997,7 @@
  </model>
 -->
     <model>
-        <path>Aircraft/f-14b/Models/Fx/smoke-trail.xml</path>
+        <path>Aircraft/f-14b/Models/Fx/smoke-trail-left.xml</path>
         <offsets>
             <x-m>8.1</x-m>
             <y-m>-3.6</y-m>
@@ -1009,7 +1009,7 @@
     </model>
 
     <model>
-        <path>Aircraft/f-14b/Models/Fx/smoke-trail.xml</path>
+        <path>Aircraft/f-14b/Models/Fx/smoke-trail-right.xml</path>
         <offsets>
             <x-m>8.1</x-m>
             <y-m> 3.6</y-m>

--- a/aircraft/f-14b/f-14-common.xml
+++ b/aircraft/f-14b/f-14-common.xml
@@ -960,6 +960,16 @@
                     <aircraft-agl-height userarchive="y" type="double">7.728680129</aircraft-agl-height>
                     <!--                    <init-delay type="int">0.1</init-delay> -->
                 </overrides>
+		<vapour-color n="0">
+			<r type="float">1.0</r>
+			<g type="float">1.0</g>
+			<b type="float">1.0</b>
+		</vapour-color>
+		<vapour-color n="1">
+			<r type="float">1.0</r>
+			<g type="float">1.0</g>
+			<b type="float">1.0</b>
+		</vapour-color>
             </f-14b>
         </model>
 
@@ -990,6 +1000,12 @@
                 <!-- /fdm/jsbsim/propulsion/engine[0]/alt/nozzle-pos-norm" -->
                 <float n="11">0</float>
                 <!-- /fdm/jsbsim/propulsion/engine[1]/alt/nozzle-pos-norm" -->
+		<float n="12" alias="/sim/model/f-14b/vapour-color[0]/r"/>
+		<float n="13" alias="/sim/model/f-14b/vapour-color[0]/g"/>
+		<float n="14" alias="/sim/model/f-14b/vapour-color[0]/b"/>
+		<float n="15" alias="/sim/model/f-14b/vapour-color[1]/r"/>
+		<float n="16" alias="/sim/model/f-14b/vapour-color[1]/g"/>
+		<float n="17" alias="/sim/model/f-14b/vapour-color[1]/b"/>
                 <int n="0" type="int">0</int>
                 <!-- fuel dump      -->
                 <int n="1" type="int">0</int>
@@ -1119,6 +1135,13 @@
                         <binding>
                             <command>nasal</command>
                             <script>f14.cold_and_dark()</script>
+                        </binding>
+                    </item>
+                    <item n="10">
+                        <label>Vapour Color Dialog</label>
+                        <binding>
+                            <command>dialog-show</command>
+			    <dialog-name>vapour-color</dialog-name>
                         </binding>
                     </item>
                 </menu>

--- a/aircraft/f-14b/gui/dialogs/vapour-color.xml
+++ b/aircraft/f-14b/gui/dialogs/vapour-color.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<PropertyList>
+	
+	<name>vapour-color</name>
+	<layout>vbox</layout>
+	
+	<group>
+		<layout>hbox</layout>
+		<text>
+			<halign>left</halign>
+			<label>Vapour Color</label>
+		</text>
+		<empty><stretch>1</stretch></empty>
+		<button>
+			<halign>right</halign>
+			<pref-width>20</pref-width>
+			<pref-height>20</pref-height>
+			<legend>X</legend>
+			<key>Esc</key>
+			<binding>
+				<command>dialog-close</command>
+			</binding>
+		</button>
+	</group>
+	
+	<hrule/>
+	
+	<group>
+		<layout>vbox</layout>
+
+		<text>
+			<halign>left</halign>
+			<label>Vapour Color:</label>
+		</text>
+		
+		<group>
+			<layout>hbox</layout>
+			<text>
+				<label>Left</label>
+			</text>
+			<group>
+				<layout>vbox</layout>
+				<text>
+					<label>Red</label>
+				</text>
+				<slider>
+					<halign>right</halign>
+					<pref-width>150</pref-width>
+					<property>/sim/model/f-14b/vapour-color[0]/r</property>
+					<min>0.0</min>
+					<max>1.0</max>
+					<binding>
+						<command>dialog-apply</command>
+					</binding>
+					<live>true</live>
+				</slider>
+			</group>
+			<group>
+				<layout>vbox</layout>
+				<text>
+					<label>Green</label>
+				</text>
+				<slider>
+					<halign>right</halign>
+					<pref-width>150</pref-width>
+					<property>/sim/model/f-14b/vapour-color[0]/g</property>
+					<min>0.0</min>
+					<max>1.0</max>
+					<binding>
+						<command>dialog-apply</command>
+					</binding>
+					<live>true</live>
+				</slider>
+			</group>
+			<group>
+				<layout>vbox</layout>
+				<text>
+					<label>Blue</label>
+				</text>
+				<slider>
+					<halign>right</halign>
+					<pref-width>150</pref-width>
+					<property>/sim/model/f-14b/vapour-color[0]/b</property>
+					<min>0.0</min>
+					<max>1.0</max>
+					<binding>
+						<command>dialog-apply</command>
+					</binding>
+					<live>true</live>
+				</slider>
+			</group>
+		</group>
+		<group>
+			<layout>hbox</layout>
+			<text>
+				<label>Right</label>
+			</text>
+			<group>
+				<layout>vbox</layout>
+				<text>
+					<label>Red</label>
+				</text>
+				<slider>
+					<halign>right</halign>
+					<pref-width>150</pref-width>
+					<property>/sim/model/f-14b/vapour-color[1]/r</property>
+					<min>0.0</min>
+					<max>1.0</max>
+					<binding>
+						<command>dialog-apply</command>
+					</binding>
+					<live>true</live>
+				</slider>
+			</group>
+			<group>
+				<layout>vbox</layout>
+				<text>
+					<label>Green</label>
+				</text>
+				<slider>
+					<halign>right</halign>
+					<pref-width>150</pref-width>
+					<property>/sim/model/f-14b/vapour-color[1]/g</property>
+					<min>0.0</min>
+					<max>1.0</max>
+					<binding>
+						<command>dialog-apply</command>
+					</binding>
+					<live>true</live>
+				</slider>
+			</group>
+			<group>
+				<layout>vbox</layout>
+				<text>
+					<label>Blue</label>
+				</text>
+				<slider>
+					<halign>right</halign>
+					<pref-width>150</pref-width>
+					<property>/sim/model/f-14b/vapour-color[1]/b</property>
+					<min>0.0</min>
+					<max>1.0</max>
+					<binding>
+						<command>dialog-apply</command>
+					</binding>
+					<live>true</live>
+				</slider>
+			</group>
+		</group>
+		
+	</group>
+	
+</PropertyList>


### PR DESCRIPTION
This is the result of an FG "teaching" session with Thilo over Discord - customizable smoke colors individually for left and right. Merge it if you like or don't ;)

The MP implementation using the generic protocol might be inefficient and should probably be better done using emesary (?) but I have no idea how to ;)