### PR TITLE
RIO: Fix missing damage namespace, datalink.nas error

### DIFF
--- a/aircraft/f-14b/f-14-common.xml
+++ b/aircraft/f-14b/f-14-common.xml
@@ -2838,13 +2838,6 @@ HSD:   Horisontal Situation Display: Pilot right Front Panel: controls mode and 
     </f14>
 
     <nasal>
-        <!-- IFF And Datalink -->
-        <iff>
-            <file>Aircraft/f-14b/Nasal/iff.nas</file>
-        </iff>
-        <datalink>
-            <file>Aircraft/f-14b/Nasal/datalink.nas</file>
-        </datalink>
         <!--emesary>
             <file>Aircraft/f-14b/Nasal/emesary.nas</file>
         </emesary>
@@ -2891,6 +2884,12 @@ HSD:   Horisontal Situation Display: Pilot right Front Panel: controls mode and 
         <an_arc_159v1>
             <file>Aircraft/f-14b/Nasal/an-arc-159v1.nas</file>
         </an_arc_159v1>
+        <iff>
+            <file>Aircraft/f-14b/Nasal/iff.nas</file>
+        </iff>
+        <datalink>
+            <file>Aircraft/f-14b/Nasal/datalink.nas</file>
+        </datalink>
         <f14>
             <file>Aircraft/f-14b/Nasal/M_exec.nas</file>
             <file>Aircraft/f-14b/Nasal/liveries.nas</file>

--- a/aircraft/f-14b/f-14b-bs-set.xml
+++ b/aircraft/f-14b/f-14b-bs-set.xml
@@ -890,8 +890,7 @@
             <station-name type="string">station</station-name>
             <hit-interpolation type="bool">true</hit-interpolation>
             <enable-craters type="bool">true</enable-craters>
-            <msg type="bool">false</msg>
-            <damage type="bool">false</damage>
+            <msg type="bool">true</msg>
             <MLW-bearing type="double">0</MLW-bearing>
             <MLW-count type="int">0</MLW-count>
             <MLW-launcher type="string"></MLW-launcher>
@@ -967,15 +966,15 @@
     </debug-radar>
 
 	<nasal>
-		<iff>
-            <file>Aircraft/f-14b/Nasal/iff.nas</file>
-        </iff>
-        <datalink>
-            <file>Aircraft/f-14b/Nasal/datalink.nas</file>
-        </datalink>
 		<!--radardist>
 			<file>Aircraft/Instruments-3d/radardist/radardist.nas</file>
 		</radardist-->
+        <notifications>
+            <file>Aircraft/f-14b/Nasal/AircraftEventNotification.nas</file>
+            <file>Aircraft/f-14b/Nasal/ArmamentNotification.nas</file>
+            <file>Aircraft/f-14b/Nasal/M_frame_notification.nas</file>
+            <file>Aircraft/f-14b/Nasal/GeoBridgedTransmitter.nas</file>
+        </notifications>
         <vector>
             <file>Aircraft/f-14b/Nasal/vector.nas</file>
         </vector>
@@ -983,6 +982,18 @@
             <file>Aircraft/f-14b/Nasal/Radar/rcs_mand.nas</file>
             <file>Aircraft/f-14b/Nasal/Radar/rcs.nas</file>
         </rcs>
+        <damage>
+            <file>Aircraft/f-14b/Nasal/damage.nas</file>
+        </damage>
+        <armament>
+            <file>Aircraft/f-14b/Nasal/fox2.nas</file>
+        </armament>
+        <iff>
+            <file>Aircraft/f-14b/Nasal/iff.nas</file>
+        </iff>
+        <datalink>
+            <file>Aircraft/f-14b/Nasal/datalink.nas</file>
+        </datalink>
 		<awg_9>
             <file>Aircraft/f-14b/Nasal/Radar/radar-system.nas</file>
             <file>Aircraft/f-14b/Nasal/Radar/awg-9.nas</file>


### PR DESCRIPTION
Damage namespace is needed for Datalink.nas as of November 2022. MP RIO up until now did not have damage implemented.

- Added Damage and notifications namespaces (notifications being requirement for damage)
- MP Damage is ON by default, can be toggled off using the menu item in Tomcat controls while on ground.
- Datalink namespace has been moved down for both F-14 pilot and F-14 MP RIO instances to allow damage being defined before datalink gets called, suppressing nasal error.
