### PR TITLE
Fix nasal error caused by F-15 multiplayer model

### DIFF
--- a/aircraft/F-15/Nasal/mp-network.nas
+++ b/aircraft/F-15/Nasal/mp-network.nas
@@ -97,7 +97,7 @@ var update_ext_load = func(sender, state)
         {
 			var ccc = c-2;
 			var cc = c-1;
-			str = chr(wpstr[ccc]) ~ chr(wpstr[cc]) ~ chr(wpstr[c]);
+			var str = chr(wpstr[ccc]) ~ chr(wpstr[cc]) ~ chr(wpstr[c]);
 			if ( str == "001" ) { o = "AIM-9" }
 			elsif ( str == "010") { o = "AIM-7" }
 			elsif ( str == "011") { o = "AIM-120" }
@@ -124,7 +124,7 @@ var update_ext_load = func(sender, state)
 
 			o = "none";
 			var cc = c-1;
-			str = chr(wpstr[cc]) ~ chr(wpstr[c]);
+			var str = chr(wpstr[cc]) ~ chr(wpstr[c]);
 			Station = Wnode.getChild ("station", s , 1);
 			Station.getNode("selected", 1).setBoolValue(0);
 			if ( str == "01" ) { 


### PR DESCRIPTION
In FG 2020.4, str() in the global nasal namespace is a function to convert to strings. Assigning to 'str' without declaring it as variable

    str = [...]

overwrites this global function, affecting all namespaces. Since mp-network.nas is loaded from the model xml file, this can also happen when loading the F-15 as a MP model.  This caused errors in the Viggen which uses the str() function.

Change the assignment to keep the variable local:

    var str = [...]